### PR TITLE
fix: race condition in readiness #28

### DIFF
--- a/internal/controller/metalstackcluster_controller_test.go
+++ b/internal/controller/metalstackcluster_controller_test.go
@@ -273,6 +273,7 @@ var _ = Describe("MetalStackCluster Controller", func() {
 				"Type":   Equal(v1alpha1.ClusterControlPlaneEndpointEnsured),
 				"Status": Equal(corev1.ConditionTrue),
 			})))
+			Expect(resource.Status.Ready).To(BeTrue())
 
 			By("ssh keypair generation")
 			sshSecret := &corev1.Secret{
@@ -386,6 +387,8 @@ var _ = Describe("MetalStackCluster Controller", func() {
 						"Status": Equal(corev1.ConditionTrue),
 					}),
 				))
+
+				Expect(resource.Status.Ready).To(BeTrue())
 			})
 		})
 
@@ -460,6 +463,8 @@ var _ = Describe("MetalStackCluster Controller", func() {
 					"Reason":  Equal("InternalError"),
 					"Message": ContainSubstring("ip not found"),
 				})))
+
+				Expect(resource.Status.Ready).To(BeFalse())
 			})
 		})
 	})


### PR DESCRIPTION
## Description

Fixes #28 
There was a race condition leading to the readiness being computed before the actual condition checks have finished. This lead to `Ready: false` in most cases.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
