### PR TITLE
Add custom columns for capms resources

### DIFF
--- a/api/v1alpha1/metalstackcluster_types.go
+++ b/api/v1alpha1/metalstackcluster_types.go
@@ -106,6 +106,13 @@ type MetalStackClusterStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this MetalStackCluster belongs"
+// +kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".spec.controlPlaneEndpoint.host",description="Control plane API endpoint"
+// +kubebuilder:printcolumn:name="Partition",type="string",priority=1,JSONPath=".spec.partition",description="The partition within metal-stack"
+// +kubebuilder:printcolumn:name="Project",type="string",priority=1,JSONPath=".spec.projectID",description="The project within metal-stack"
+// +kubebuilder:printcolumn:name="Network",type="string",priority=1,JSONPath=".status.nodeNetworkID",description="The network within metal-stack"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="MetalStackCluster is ready"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Uptime of the cluster"
 
 // MetalStackCluster is the Schema for the metalstackclusters API.
 type MetalStackCluster struct {

--- a/api/v1alpha1/metalstackmachine_types.go
+++ b/api/v1alpha1/metalstackmachine_types.go
@@ -72,6 +72,13 @@ type MetalStackMachineStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this MetalStackMachine belongs"
+// +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="ProviderID reference for the MetalStackMachine"
+// +kubebuilder:printcolumn:name="Size",type="string",JSONPath=".spec.size",priority=1,description="Size of the MetalStackMachine"
+// +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".spec.image",description="OS image of the MetalStackMachine"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="MetalStackMachine is ready for worker nodes"
+// +kubebuilder:printcolumn:name="Healthy",type="string",JSONPath=".status.conditions[1].status",description="Health of the provider machine"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // MetalStackMachine is the Schema for the metalstackmachines API.
 type MetalStackMachine struct {

--- a/api/v1alpha1/metalstackmachinetemplate_types.go
+++ b/api/v1alpha1/metalstackmachinetemplate_types.go
@@ -29,6 +29,9 @@ type MetalStackMachineTemplateSpec struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Size",type="string",JSONPath=".spec.template.spec.size",description="Size of the MetalStackMachine"
+// +kubebuilder:printcolumn:name="Image",type="string",JSONPath=".spec.template.spec.image",description="OS image of the MetalStackMachine"
 
 // MetalStackMachineTemplate is the Schema for the inframachinetemplates API.
 type MetalStackMachineTemplate struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metalstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metalstackclusters.yaml
@@ -14,7 +14,39 @@ spec:
     singular: metalstackcluster
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Cluster to which this MetalStackCluster belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: Control plane API endpoint
+      jsonPath: .spec.controlPlaneEndpoint.host
+      name: Endpoint
+      type: string
+    - description: The partition within metal-stack
+      jsonPath: .spec.partition
+      name: Partition
+      priority: 1
+      type: string
+    - description: The project ID within metal-stack
+      jsonPath: .spec.projectID
+      name: Project
+      priority: 1
+      type: string
+    - description: The network ID within metal-stack
+      jsonPath: .status.nodeNetworkID
+      name: Network
+      priority: 1
+      type: string
+    - description: MetalStackCluster is ready
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Uptime of the cluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: MetalStackCluster is the Schema for the metalstackclusters API.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metalstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metalstackclusters.yaml
@@ -28,12 +28,12 @@ spec:
       name: Partition
       priority: 1
       type: string
-    - description: The project ID within metal-stack
+    - description: The project within metal-stack
       jsonPath: .spec.projectID
       name: Project
       priority: 1
       type: string
-    - description: The network ID within metal-stack
+    - description: The network within metal-stack
       jsonPath: .status.nodeNetworkID
       name: Network
       priority: 1

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metalstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metalstackmachines.yaml
@@ -36,12 +36,13 @@ spec:
       jsonPath: .status.ready
       name: Ready
       type: string
+    - description: Health of the provider machine
+      jsonPath: .status.conditions[1].status
+      name: Healthy
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - jsonPath: .status.conditions[1].status
-      name: Healthy
-      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metalstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metalstackmachines.yaml
@@ -14,7 +14,35 @@ spec:
     singular: metalstackmachine
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Cluster to which this MetalStackMachine belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: ProviderID reference for the MetalStackMachine
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Size of the MetalStackMachine
+      jsonPath: .spec.size
+      name: Size
+      priority: 1
+      type: string
+    - description: OS image of the MetalStackMachine
+      jsonPath: .spec.image
+      name: Image
+      type: string
+    - description: MetalStackMachine is ready for worker nodes
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[1].status
+      name: Healthy
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: MetalStackMachine is the Schema for the metalstackmachines API.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metalstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metalstackmachinetemplates.yaml
@@ -14,7 +14,19 @@ spec:
     singular: metalstackmachinetemplate
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Size of the MetalStackMachine
+      jsonPath: .spec.template.spec.size
+      name: Size
+      type: string
+    - description: OS image of the MetalStackMachine
+      jsonPath: .spec.template.spec.image
+      name: Image
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: MetalStackMachineTemplate is the Schema for the inframachinetemplates
@@ -175,3 +187,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}


### PR DESCRIPTION
## Description

Adds custom columns for ClusterAPI metal-stack machine and cluster resources. More detailed columns become visible by specifying `-o wide` in the command.

References: #19

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
