### PR TITLE
Refactor deletion flow

### DIFF
--- a/internal/controller/metalstackcluster_controller.go
+++ b/internal/controller/metalstackcluster_controller.go
@@ -183,17 +183,17 @@ func (r *clusterReconciler) delete() error {
 
 	r.log.Info("reconciling resource deletion flow")
 
-	err = r.deleteControlPlaneIP()
-	if err != nil {
-		return fmt.Errorf("unable to delete control plane ip: %w", err)
-	}
-	r.infraCluster.Spec.ControlPlaneIP = nil
-
 	err = r.deleteNodeNetwork()
 	if err != nil {
 		return fmt.Errorf("unable to delete node network: %w", err)
 	}
 	r.infraCluster.Spec.NodeNetworkID = nil
+
+	err = r.deleteControlPlaneIP()
+	if err != nil {
+		return fmt.Errorf("unable to delete control plane ip: %w", err)
+	}
+	r.infraCluster.Spec.ControlPlaneIP = nil
 
 	r.log.Info("deletion finished, removing finalizer")
 	controllerutil.RemoveFinalizer(r.infraCluster, v1alpha1.ClusterFinalizer)


### PR DESCRIPTION
## Description

Refactors the deletion flow to delete the control plane IP after the node network. This ensures that the machines are deleted, before the control plane IP gets deleted.

References: #35 

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
