### PR TITLE
feat: make nodeNetworkID mandatory

### DIFF
--- a/api/v1alpha1/metalstackcluster_types.go
+++ b/api/v1alpha1/metalstackcluster_types.go
@@ -31,7 +31,6 @@ const (
 
 	ClusterControlPlaneEndpointDefaultPort = 443
 
-	ClusterNodeNetworkEnsured    clusterv1.ConditionType = "ClusterNodeNetworkEnsured"
 	ClusterControlPlaneIPEnsured clusterv1.ConditionType = "ClusterControlPlaneIPEnsured"
 )
 
@@ -52,9 +51,7 @@ type MetalStackClusterSpec struct {
 	ProjectID string `json:"projectID"`
 
 	// NodeNetworkID is the network ID in metal-stack in which the worker nodes and the firewall of the cluster are placed.
-	// If not provided this will automatically be acquired during reconcile.
-	// +optional
-	NodeNetworkID *string `json:"nodeNetworkID,omitempty"`
+	NodeNetworkID string `json:"nodeNetworkID"`
 
 	// ControlPlaneIP is the ip address in metal-stack on which the control plane will be exposed.
 	// If this ip and the control plane endpoint are not provided, an ephemeral ip will automatically be acquired during reconcile.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -104,11 +104,6 @@ func (in *MetalStackClusterList) DeepCopyObject() runtime.Object {
 func (in *MetalStackClusterSpec) DeepCopyInto(out *MetalStackClusterSpec) {
 	*out = *in
 	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
-	if in.NodeNetworkID != nil {
-		in, out := &in.NodeNetworkID, &out.NodeNetworkID
-		*out = new(string)
-		**out = **in
-	}
 	if in.ControlPlaneIP != nil {
 		in, out := &in.ControlPlaneIP, &out.ControlPlaneIP
 		*out = new(string)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_metalstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_metalstackclusters.yaml
@@ -92,9 +92,8 @@ spec:
                   Static ip addresses will not be deleted.
                 type: string
               nodeNetworkID:
-                description: |-
-                  NodeNetworkID is the network ID in metal-stack in which the worker nodes and the firewall of the cluster are placed.
-                  If not provided this will automatically be acquired during reconcile.
+                description: NodeNetworkID is the network ID in metal-stack in which
+                  the worker nodes and the firewall of the cluster are placed.
                 type: string
               partition:
                 description: Partition is the data center partition in which the resources
@@ -105,6 +104,7 @@ spec:
                   in which the associated metal-stack resources are created.
                 type: string
             required:
+            - nodeNetworkID
             - partition
             - projectID
             type: object

--- a/internal/controller/metalstackmachine_controller.go
+++ b/internal/controller/metalstackmachine_controller.go
@@ -172,11 +172,6 @@ func (r *MetalStackMachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *machineReconciler) reconcile() (ctrl.Result, error) {
-	if r.infraCluster.Spec.NodeNetworkID == nil {
-		// this should not happen because before setting this id the cluster status should not become ready, but we check it anyway
-		return ctrl.Result{}, errors.New("waiting until node network id was set to infrastructure cluster status")
-	}
-
 	if r.infraCluster.Spec.ControlPlaneEndpoint.Host == "" {
 		return ctrl.Result{}, errors.New("waiting until control plane ip was set to infrastructure cluster spec")
 	}
@@ -276,7 +271,7 @@ func (r *machineReconciler) create() (*models.V1MachineResponse, error) {
 		nws = []*models.V1MachineAllocationNetwork{
 			{
 				Autoacquire: ptr.To(true),
-				Networkid:   r.infraCluster.Spec.NodeNetworkID,
+				Networkid:   &r.infraCluster.Spec.NodeNetworkID,
 			},
 		}
 	)


### PR DESCRIPTION

## Description

Currently the cluster controller will never be able to delete the node network - even if all machines have been deleted, because the firewall is unmanaged. This requires the node network to also be unmanaged. 

References: 
- #39 

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
