### PR TITLE
docs: fix environment variables for init metal-stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ providers:
 Now you are able to install the CAPMS into your cluster:
 
 ```bash
-export METALCTL_API_URL=http://metal.203.0.113.1.nip.io:8080
-export METALCTL_API_HMAC=metal-admin
+export METAL_API_URL=http://metal.203.0.113.1.nip.io:8080
+export METAL_API_HMAC=metal-admin
 export EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION=true
 
 clusterctl init --infrastructure metal-stack


### PR DESCRIPTION
## Description

When running the instructions to set up our metal-stack provider, I got the following error:

```bash
$ export METALCTL_API_URL=http://metal.203.0.113.1.nip.io:8080                  
$ export METALCTL_API_HMAC=metal-admin
$ export EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION=true
$ clusterctl init --infrastructure metal-stack
Fetching providers
Error: failed to get provider components for the "metal-stack" provider: failed to perform variable substitution: value for variables [METAL_API_HMAC, METAL_API_URL] is not set. Please set the value using os environment variables or the clusterctl config file
```

The correct names do not include `CTL`.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
