### PR TITLE
Draft: proof of concept for firewall machine deployments

### DIFF
--- a/capi-lab/Makefile
+++ b/capi-lab/Makefile
@@ -20,6 +20,8 @@ CONTROL_PLANE_MACHINE_IMAGE ?= ubuntu-24.04
 CONTROL_PLANE_MACHINE_SIZE ?= v1-small-x86
 WORKER_MACHINE_IMAGE ?= ubuntu-24.04
 WORKER_MACHINE_SIZE ?= v1-small-x86
+FIREWALL_MACHINE_IMAGE ?= firewall-ubuntu-3.0
+FIREWALL_MACHINE_SIZE ?= v1-small-x86
 
 IMG ?= ghcr.io/metal-stack/cluster-api-metal-stack-controller:latest
 

--- a/config/clusterctl-templates/cluster-template.yaml
+++ b/config/clusterctl-templates/cluster-template.yaml
@@ -137,3 +137,50 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-firewall
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+    nodepool: firewall
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+      nodepool: firewall
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+        nodepool: firewall
+    spec:
+      nodeDrainTimeout: 120s
+      clusterName: ${CLUSTER_NAME}
+      version: "${KUBERNETES_VERSION}"
+      bootstrap:
+        dataSecretName: ${CLUSTER_NAME}-firewall-data
+      infrastructureRef:
+        name: ${CLUSTER_NAME}-firewall
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: MetalStackMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: MetalStackMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-firewall
+spec:
+  template:
+    spec:
+      size: ${FIREWALL_MACHINE_SIZE}
+      image: ${FIREWALL_MACHINE_IMAGE}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${CLUSTER_NAME}-firewall-data
+stringData:
+  value: "{}"


### PR DESCRIPTION
## Description

> [!CAUTION]
> DO NOT MERGE!

Proof of concept whether it is possible to use `MachineDeployment`s to create and roll firewalls.
At a first glance this looks promising and it should be possible to implement.

To make this production ready:

- Add `MetalStackFirewall` which implements the infra machine protocol
  - with firewall rules
- Separate controller for the metalstackfirewall
  - needs to set `machine.bootstrap.dataSecretName` and needs to generate the secret containing User Data (this is slightly off the contract)

This should enable automatic rolling updates of the firewall whenever the firewall rules change. All handled by cluster api.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
