### PR TITLE
feat: reconcile associated resources

### DIFF
--- a/internal/controller/metalstackcluster_controller.go
+++ b/internal/controller/metalstackcluster_controller.go
@@ -190,6 +190,7 @@ func (r *MetalStackClusterReconciler) clusterToMetalStackCluster(log logr.Logger
 			return nil
 		}
 
+		log.Info("cluster watch reconcile", "infraCluster", infraCluster.Name)
 		return []ctrl.Request{
 			{
 				NamespacedName: infraName,
@@ -256,6 +257,7 @@ func (r *MetalStackClusterReconciler) metalStackMachineToMetalStackCluster(log l
 			return nil
 		}
 
+		log.Info("ms machine watch reconcile", "infraCluster", infraCluster.Name)
 		return []ctrl.Request{
 			{
 				NamespacedName: client.ObjectKeyFromObject(infraCluster),

--- a/internal/controller/metalstackcluster_controller.go
+++ b/internal/controller/metalstackcluster_controller.go
@@ -23,12 +23,16 @@ import (
 	"net/http"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -142,8 +146,122 @@ func (r *MetalStackClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&v1alpha1.MetalStackCluster{}).
 		Named("metalstackcluster").
 		WithEventFilter(predicates.ResourceIsNotExternallyManaged(mgr.GetScheme(), mgr.GetLogger())).
-		// TODO: implement resource paused from cluster-api's predicates?
+		WithEventFilter(predicates.ResourceNotPaused(mgr.GetScheme(), mgr.GetLogger())).
+		Watches(
+			&clusterv1.Cluster{},
+			handler.EnqueueRequestsFromMapFunc(r.clusterToMetalStackCluster(mgr.GetLogger())),
+			builder.WithPredicates(predicates.ClusterUnpaused(mgr.GetScheme(), mgr.GetLogger())),
+		).
+		Watches(&v1alpha1.MetalStackMachine{},
+			handler.EnqueueRequestsFromMapFunc(r.metalStackMachineToMetalStackCluster(mgr.GetLogger())),
+			builder.WithPredicates(predicates.ResourceNotPaused(mgr.GetScheme(), mgr.GetLogger())),
+		).
 		Complete(r)
+}
+
+func (r *MetalStackClusterReconciler) clusterToMetalStackCluster(log logr.Logger) handler.MapFunc {
+	return func(ctx context.Context, o client.Object) []ctrl.Request {
+		cluster, ok := o.(*clusterv1.Cluster)
+		if !ok {
+			log.Error(fmt.Errorf("expected a cluster, got %T", o), "failed to get cluster", "object", o)
+			return nil
+		}
+
+		log := log.WithValues("cluster", cluster)
+
+		if cluster.Spec.InfrastructureRef == nil {
+			return nil
+		}
+		if cluster.Spec.InfrastructureRef.GroupVersionKind().Kind != "MetalStackCluster" {
+			return nil
+		}
+
+		infraCluster := &v1alpha1.MetalStackCluster{}
+		infraName := types.NamespacedName{
+			Namespace: cluster.Spec.InfrastructureRef.Namespace,
+			Name:      cluster.Spec.InfrastructureRef.Name,
+		}
+
+		if err := r.Client.Get(ctx, infraName, infraCluster); err != nil {
+			log.Error(err, "failed to get infra cluster")
+			return nil
+		}
+		if annotations.IsExternallyManaged(infraCluster) {
+			return nil
+		}
+
+		return []ctrl.Request{
+			{
+				NamespacedName: infraName,
+			},
+		}
+	}
+}
+
+func (r *MetalStackClusterReconciler) metalStackMachineToMetalStackCluster(log logr.Logger) handler.MapFunc {
+	return func(ctx context.Context, o client.Object) []ctrl.Request {
+		infraMachine, ok := o.(*v1alpha1.MetalStackMachine)
+		if !ok {
+			log.Error(fmt.Errorf("expected an infra cluster, got %T", o), "failed to get infra machine", "object", o)
+			return nil
+		}
+
+		log := log.WithValues("namespace", infraMachine.Namespace, "infraMachine", infraMachine.Name)
+
+		machine, err := util.GetOwnerMachine(ctx, r.Client, infraMachine.ObjectMeta)
+		if err != nil {
+			log.Error(err, "failed to get owner machine")
+		}
+		if machine == nil {
+			return nil
+		}
+
+		log = log.WithValues("machine", machine.Name)
+
+		cluster, err := util.GetClusterFromMetadata(ctx, r.Client, machine.ObjectMeta)
+		if err != nil {
+			log.Error(err, "failed to get owner cluster")
+			return nil
+		}
+		if cluster == nil {
+			log.Info("machine resource has no cluster yet")
+			return nil
+		}
+
+		log = log.WithValues("cluster", cluster.Name)
+
+		infraCluster := &v1alpha1.MetalStackCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: cluster.Spec.InfrastructureRef.Namespace,
+				Name:      cluster.Spec.InfrastructureRef.Name,
+			},
+		}
+		err = r.Client.Get(ctx, client.ObjectKeyFromObject(infraCluster), infraCluster)
+		if apierrors.IsNotFound(err) {
+			log.Info("infrastructure cluster no longer exists")
+			return nil
+		}
+		if err != nil {
+			log.Error(err, "failed to get infra cluster")
+			return nil
+		}
+
+		if cluster.Spec.InfrastructureRef.GroupVersionKind().Kind != "MetalStackCluster" {
+			log.Info("different infra cluster", "kind", cluster.Spec.InfrastructureRef.GroupVersionKind().Kind)
+			return nil
+		}
+
+		if annotations.IsExternallyManaged(infraCluster) {
+			log.Info("infra cluster is externally managed")
+			return nil
+		}
+
+		return []ctrl.Request{
+			{
+				NamespacedName: client.ObjectKeyFromObject(infraCluster),
+			},
+		}
+	}
 }
 
 func (r *clusterReconciler) reconcile() error {

--- a/internal/controller/metalstackcluster_controller.go
+++ b/internal/controller/metalstackcluster_controller.go
@@ -167,7 +167,7 @@ func (r *MetalStackClusterReconciler) clusterToMetalStackCluster(log logr.Logger
 			return nil
 		}
 
-		log := log.WithValues("cluster", cluster)
+		log := log.WithValues("cluster", cluster.Name, "namespace", cluster.Namespace)
 
 		if cluster.Spec.InfrastructureRef == nil {
 			return nil
@@ -190,7 +190,7 @@ func (r *MetalStackClusterReconciler) clusterToMetalStackCluster(log logr.Logger
 			return nil
 		}
 
-		log.Info("cluster watch reconcile", "infraCluster", infraCluster.Name)
+		log.Info("cluster changed, reconcile", "infraCluster", infraCluster.Name)
 		return []ctrl.Request{
 			{
 				NamespacedName: infraName,
@@ -257,7 +257,7 @@ func (r *MetalStackClusterReconciler) metalStackMachineToMetalStackCluster(log l
 			return nil
 		}
 
-		log.Info("ms machine watch reconcile", "infraCluster", infraCluster.Name)
+		log.Info("metalstackmachine changed, reconcile", "infraCluster", infraCluster.Name)
 		return []ctrl.Request{
 			{
 				NamespacedName: client.ObjectKeyFromObject(infraCluster),

--- a/internal/controller/metalstackmachine_controller.go
+++ b/internal/controller/metalstackmachine_controller.go
@@ -210,7 +210,7 @@ func (r *MetalStackMachineReconciler) clusterToMetalStackMachine(log logr.Logger
 			return nil
 		}
 
-		log := log.WithValues("cluster", cluster)
+		log := log.WithValues("cluster", cluster.Name, "namespace", cluster.Namespace)
 
 		infraMachineList := &v1alpha1.MetalStackMachineList{}
 		err := r.Client.List(ctx, infraMachineList, &client.ListOptions{
@@ -226,7 +226,7 @@ func (r *MetalStackMachineReconciler) clusterToMetalStackMachine(log logr.Logger
 
 		var reqs []ctrl.Request
 		for _, infraMachine := range infraMachineList.Items {
-			log.Info("cluster watch reconcile", "infraMachine", infraMachine.Name)
+			log.Info("cluster changed, reconcile", "infraMachine", infraMachine.Name)
 			reqs = append(reqs, ctrl.Request{
 				NamespacedName: client.ObjectKeyFromObject(&infraMachine),
 			})
@@ -243,7 +243,7 @@ func (r *MetalStackMachineReconciler) metalStackClusterToMetalStackMachine(log l
 			return nil
 		}
 
-		log := log.WithValues("infraCluster", infraCluster)
+		log := log.WithValues("infraCluster", infraCluster.Name, "namespace", infraCluster.Namespace)
 
 		clusterName, ok := infraCluster.Labels[clusterv1.ClusterNameLabel]
 		if !ok {
@@ -264,7 +264,7 @@ func (r *MetalStackMachineReconciler) metalStackClusterToMetalStackMachine(log l
 
 		var reqs []ctrl.Request
 		for _, infraMachine := range infraMachineList.Items {
-			log.Info("mscluster watch reconcile", "infraMachine", infraMachine.Name)
+			log.Info("metalstackcluster changed, reconcile", "infraMachine", infraMachine.Name)
 			reqs = append(reqs, ctrl.Request{
 				NamespacedName: client.ObjectKeyFromObject(&infraMachine),
 			})
@@ -281,7 +281,7 @@ func (r *MetalStackMachineReconciler) machineToMetalStackMachine(log logr.Logger
 			return nil
 		}
 
-		log := log.WithValues("machine", machine)
+		log := log.WithValues("machine", machine.Name, "namespace", machine.Namespace)
 
 		clusterName, ok := machine.Labels[clusterv1.ClusterNameLabel]
 		if !ok {
@@ -312,7 +312,7 @@ func (r *MetalStackMachineReconciler) machineToMetalStackMachine(log logr.Logger
 
 		var reqs []ctrl.Request
 		for _, infraMachine := range infraMachineList.Items {
-			log.Info("machine watch reconcile", "infraMachine", infraMachine.Name)
+			log.Info("machine changed, reconcile", "infraMachine", infraMachine.Name)
 			reqs = append(reqs, ctrl.Request{
 				NamespacedName: client.ObjectKeyFromObject(&infraMachine),
 			})

--- a/internal/controller/metalstackmachine_controller.go
+++ b/internal/controller/metalstackmachine_controller.go
@@ -226,6 +226,7 @@ func (r *MetalStackMachineReconciler) clusterToMetalStackMachine(log logr.Logger
 
 		var reqs []ctrl.Request
 		for _, infraMachine := range infraMachineList.Items {
+			log.Info("cluster watch reconcile", "infraMachine", infraMachine.Name)
 			reqs = append(reqs, ctrl.Request{
 				NamespacedName: client.ObjectKeyFromObject(&infraMachine),
 			})
@@ -263,6 +264,7 @@ func (r *MetalStackMachineReconciler) metalStackClusterToMetalStackMachine(log l
 
 		var reqs []ctrl.Request
 		for _, infraMachine := range infraMachineList.Items {
+			log.Info("mscluster watch reconcile", "infraMachine", infraMachine.Name)
 			reqs = append(reqs, ctrl.Request{
 				NamespacedName: client.ObjectKeyFromObject(&infraMachine),
 			})
@@ -310,6 +312,7 @@ func (r *MetalStackMachineReconciler) machineToMetalStackMachine(log logr.Logger
 
 		var reqs []ctrl.Request
 		for _, infraMachine := range infraMachineList.Items {
+			log.Info("machine watch reconcile", "infraMachine", infraMachine.Name)
 			reqs = append(reqs, ctrl.Request{
 				NamespacedName: client.ObjectKeyFromObject(&infraMachine),
 			})


### PR DESCRIPTION

## Description

Starts a reconcile after unpausing a cluster and similar situations. This should fix missing reconciles after moving clusters.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
