### PR TITLE
fix: deletion of untouched machines

### DIFF
--- a/internal/controller/metalstackmachine_controller.go
+++ b/internal/controller/metalstackmachine_controller.go
@@ -532,6 +532,10 @@ func (r *machineReconciler) getMachineAddresses(m *models.V1MachineResponse) clu
 }
 
 func (r *machineReconciler) findProviderMachine() (*models.V1MachineResponse, error) {
+	if r.infraMachine.Spec.ProviderID == "" {
+		return nil, errProviderMachineNotFound
+	}
+
 	resp, err := r.metalClient.Machine().FindMachine(metalmachine.NewFindMachineParams().WithContext(r.ctx).WithID(decodeProviderID(r.infraMachine.Spec.ProviderID)), nil)
 
 	var errResp *metalmachine.FindMachineDefault


### PR DESCRIPTION
## Description

When trying to delete a metalstackmachine that has not yet been created, it still tried to find it. Resulting in the following error and a deadlock.

```
capms-controller-manager-8469bcdb77-qntkg manager 2025-03-06T10:52:11Z    ERROR   Reconciler error        {"controller": "metalstackmachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "MetalStackMachine", "MetalStackMachine": {"name":"metal-test-md-0-zvdmm-d4m2m","namespace":"default"}, "namespace": "default", "name": "metal-test-md-0-zvdmm-d4m2m", "reconcileID": "0fa4ed89-6f86-4062-b2f4-f32e3defc479", "error": "failed to find provider machine: json: cannot unmarshal array into Go value of type models.V1MachineResponse"}
```


<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
