### PR TITLE
Metallb BGPPeers are generated for each node and don't have to be created manually

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -85,32 +85,6 @@ If you want to provide service's of type load balancer through MetalLB by the me
 kubectl --kubeconfig capi-lab/.capms-cluster-kubeconfig.yaml apply --kustomize capi-lab/metallb
 ```
 
-For each node in your Kubernetes cluster, you need to create a BGP peer configuration. Replace the placeholders ({{
-NODE_ASN }}, {{ NODE_HOSTNAME }}, and {{ NODE_ROUTER_ID }}) with the appropriate values for each node.
-
-```bash
-cat <<EOF | kubectl --kubeconfig=capi-lab/.capms-cluster-kubeconfig.yaml create -f -
-apiVersion: metallb.io/v1beta2
-kind: BGPPeer
-metadata:
-  name: ${NODE_HOSTNAME}
-  namespace: metallb-system
-spec:
-  holdTime: 1m30s
-  keepaliveTime: 0s
-  myASN: ${NODE_ASN}
-  nodeSelectors:
-  - matchExpressions:
-    - key: kubernetes.io/hostname
-      operator: In
-      values:
-      - ${NODE_HOSTNAME}
-  passwordSecret: {}
-  peerASN: ${NODE_ASN}
-  peerAddress: ${NODE_ROUTER_ID}
-EOF
-```
-
 That's it!
 
 ### To Deploy on the cluster


### PR DESCRIPTION
## Description

metal-ccm is now able to generate the bgppeers automatically. No need to create them manually.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
