### PR TITLE
fix(machine): give load balancers some time after control plane machine deletion

### DIFF
--- a/internal/controller/metalstackmachine_controller.go
+++ b/internal/controller/metalstackmachine_controller.go
@@ -400,12 +400,12 @@ func (r *machineReconciler) delete() (ctrl.Result, error) {
 		}
 
 		if r.infraMachine.DeletionTimestamp.Add(defaultControlPlaneMachineFreeRequeueTime).Before(time.Now()) {
-			r.log.Info("control plane machine already freed for more than a minute, BGP routes should be up to date, removing finalizer")
+			r.log.Info("control plane machine deleted, removing finalizer")
 			controllerutil.RemoveFinalizer(r.infraMachine, v1alpha1.MachineFinalizer)
 			return ctrl.Result{}, nil
 		}
 
-		r.log.Info("control plane machine already freed, waiting a grace period for BGP routes to refresh")
+		r.log.Info("control plane machine deleted, giving load balancers some time to adjust")
 		return ctrl.Result{RequeueAfter: defaultControlPlaneMachineFreeRequeueTime / 2}, nil
 	}
 	if err != nil {
@@ -425,7 +425,7 @@ func (r *machineReconciler) delete() (ctrl.Result, error) {
 		return ctrl.Result{}, nil
 	}
 
-	r.log.Info("control plane machine delete finished, waiting a grace period for BGP routes to refresh")
+	r.log.Info("control plane machine delete finished, giving load balancers some to adjust")
 	return ctrl.Result{RequeueAfter: time.Minute}, nil
 }
 


### PR DESCRIPTION
## Description

During the implementation of k8s upgrades in #105, we noticed that control plane nodes could not be rotated through correctly as the deletion of these CP nodes failed:

```
NAME                                                         STATUS                        ROLES           AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION           CONTAINER-RUNTIME
node/k8s-upgrade-and-conformance-663orn-controlplane-brpgx   NotReady,SchedulingDisabled   control-plane   45m   v1.33.5   10.128.88.2   <none>        Ubuntu 24.04.3 LTS   6.12.44-061244-generic   containerd://1.7.28
node/k8s-upgrade-and-conformance-663orn-controlplane-cg59f   Ready                         control-plane   40m   v1.34.1   10.128.88.3   <none>        Ubuntu 24.04.3 LTS   6.12.44-061244-generic   containerd://1.7.28
```

```
capi-controller-manager-7c48879656-nb9fg manager I1105 07:58:39.576255       1 machine_controller.go:623] "Node deletion timeout expired, continuing without Node deletion." controller="machine" controllerGroup="cluster.x-k8s.io" controllerKind="Machine" Machine="k8s-upgrade-and-conformance-d4tsyc/k8s-upgrade-and-conformance-663orn-controlplane-brpgx" namespace="k8s-upgrade-and-conformance-d4tsyc" name="k8s-upgrade-and-conformance-663orn-controlplane-brpgx" reconcileID="4c4b8b53-1e22-40fb-a6fc-f4bf3c84afb2" Cluster="k8s-upgrade-and-conformance-d4tsyc/k8s-upgrade-and-conformance-663orn" KubeadmControlPlane="k8s-upgrade-and-conformance-d4tsyc/k8s-upgrade-and-conformance-663orn-controlplane"
```

This is most likely triggered by the kube-vip BGP IP not being revoked in time.
This PR tries to test and validate this theory by waiting some additional time after the metal-machine deletion before removing the metalstackmachine finalizer to give the network some time to adjust.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
