### PR TITLE
build: build kustomize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ E2E_LABEL_FILTER ?= ""
 
 E2E_TEMPLATES := test/e2e/frmwrk/data/clusterctl-templates
 .PHONY: test-e2e
-test-e2e: manifests generate fmt vet ginkgo
+test-e2e: manifests generate fmt vet ginkgo kustomize
 	rm -rf $(ARTIFACTS)
 
 	$(KUSTOMIZE) build $(E2E_TEMPLATES)/upgrade --load-restrictor LoadRestrictionsNone > $(E2E_TEMPLATES)/cluster-template-upgrade.yaml


### PR DESCRIPTION
## Description

Fixes the following error when running `make test-e2e`

```
/builds/cloud-native/metal/metal-deployment/cluster-api-provider-metal-stack/bin/kustomize build test/e2e/frmwrk/data/clusterctl-templates/upgrade --load-restrictor LoadRestrictionsNone > test/e2e/frmwrk/data/clusterctl-templates/cluster-template-upgrade.yaml
bash: line 1: /builds/cloud-native/metal/metal-deployment/cluster-api-provider-metal-stack/bin/kustomize: No such file or directory
```

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
