### PR TITLE
test(e2e): fix picking default kubeconfig accidentially

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ test-e2e-controller: manifests generate update-test-crds fmt vet ## Run the e2e 
 	}
 	go test ./test/e2e/ -v -ginkgo.v
 
+E2E_KUBECONFIG ?= ""
 E2E_METAL_API_URL ?= "$(METALCTL_API_URL)"
 E2E_METAL_API_HMAC ?= "$(METALCTL_HMAC)"
 E2E_METAL_API_HMAC_AUTH_TYPE ?= "$(or $(METALCTL_HMAC_AUTH_TYPE),Metal-Admin)"
@@ -149,7 +150,8 @@ test-e2e: manifests generate fmt vet ginkgo kustomize
 	$(KUSTOMIZE) build $(E2E_TEMPLATES)/upgrade --load-restrictor LoadRestrictionsNone > $(E2E_TEMPLATES)/cluster-template-upgrade.yaml
 	$(KUSTOMIZE) build $(E2E_TEMPLATES)/upgrade-workerless --load-restrictor LoadRestrictionsNone > $(E2E_TEMPLATES)/cluster-template-upgrade-workerless.yaml
 	
-	@METAL_API_URL=$(E2E_METAL_API_URL) \
+	@KUBECONFIG=$(E2E_KUBECONFIG) \
+	METAL_API_URL=$(E2E_METAL_API_URL) \
 	METAL_API_HMAC=$(E2E_METAL_API_HMAC) \
 	METAL_API_HMAC_AUTH_TYPE=$(E2E_METAL_API_HMAC_AUTH_TYPE) \
 	METAL_PROJECT_ID=$(E2E_METAL_PROJECT_ID) \

--- a/test/e2e/frmwrk/shared_cluster.go
+++ b/test/e2e/frmwrk/shared_cluster.go
@@ -318,6 +318,7 @@ func (e2e *E2ECluster) GenerateAndApplyClusterTemplate(ctx context.Context) {
 		Flavor:                   e2e.E2EContext.Environment.Flavor,
 		LogFolder:                path.Join(e2e.E2EContext.Environment.artifactsPath, "clusters", e2e.ClusterName),
 		ClusterctlVariables:      e2e.Variables(),
+		KubeconfigPath:           e2e.E2EContext.Environment.Bootstrap.GetKubeconfigPath(),
 	})
 
 	By("Apply cluster template")

--- a/test/e2e/frmwrk/shared_context.go
+++ b/test/e2e/frmwrk/shared_context.go
@@ -66,7 +66,7 @@ func (e2e *E2EContext) envOrVar(name string) string {
 
 func withDefaultEnvironment() Option {
 	return func(e2e *E2EContext) {
-		e2e.Environment.kubeconfigPath = os.Getenv("E2E_KUBECONFIG")
+		e2e.Environment.kubeconfigPath = os.Getenv("KUBECONFIG")
 
 		if p, ok := os.LookupEnv("ARTIFACTS"); ok {
 			e2e.Environment.artifactsPath = p
@@ -166,8 +166,8 @@ func (ee *E2EContext) ProvideBootstrapCluster() {
 }
 
 func (ee *E2EContext) provideExistingBootstrapClusterKubeconfig() string {
-	Expect(ee.Environment.kubeconfigPath).ToNot(BeEmpty(), "E2E_KUBECONFIG must be set to use an existing bootstrap cluster")
-	Expect(ee.Environment.kubeconfigPath).To(BeAnExistingFile(), "E2E_KUBECONFIG must point to an existing file")
+	Expect(ee.Environment.kubeconfigPath).ToNot(BeEmpty(), "KUBECONFIG must be set to use an existing bootstrap cluster")
+	Expect(ee.Environment.kubeconfigPath).To(BeAnExistingFile(), "KUBECONFIG must point to an existing file")
 	return ee.Environment.kubeconfigPath
 }
 


### PR DESCRIPTION
## Description

None

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
