### PR TITLE
test: upgrade contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ E2E_FIREWALL_NETWORKS ?= "internet-mini-lab"
 ARTIFACTS ?= "$(PWD)/_artifacts"
 E2E_DEFAULT_FLAVOR ?= "calico"
 E2E_PROVIDER_CONTRACT ?= "v1beta2"
+E2E_PROVIDER_CONTRACT_UPGRADE_FROM ?= "v1beta1"
 E2E_PROVIDER_VERSION ?= ""
 # Can be something like: basic && !move
 E2E_LABEL_FILTER ?= ""
@@ -173,6 +174,7 @@ test-e2e: manifests generate fmt vet ginkgo kustomize
 	ARTIFACTS=$(ARTIFACTS) \
 	E2E_DEFAULT_FLAVOR=$(E2E_DEFAULT_FLAVOR) \
 	PROVIDER_CONTRACT=$(E2E_PROVIDER_CONTRACT) \
+	PROVIDER_CONTRACT_UPGRADE_FROM=$(E2E_PROVIDER_CONTRACT_UPGRADE_FROM) \
 	PROVIDER_VERSION=$(E2E_PROVIDER_VERSION) \
 	KUBETEST_CONFIGURATION="$(shell git rev-parse --show-toplevel)/test/e2e/frmwrk/data/kubetest/conformance.yaml" \
 	$(GINKGO) -vv -r --junit-report="junit.e2e_suite.xml" --output-dir="$(ARTIFACTS)" --label-filter="$(E2E_LABEL_FILTER)" -timeout 120m ./test/e2e/frmwrk


### PR DESCRIPTION
## Description

When using a cluster with cluster api installed, the  `clusterctl.InitManagementClusterAndWatchControllerLogs` will be a no-op.
In that case `clusterctl.UpgradeManagementClusterAndWait` will be required to enforce the correct versions.

As an idea, I thought about always starting with `v1beta1` and then upgrading to `v1beta2`. This way the upgrade path would be in every test. What do you think?

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
