### PR TITLE
test(e2e): more graceful deletion of namespaces

### DIFF
--- a/test/e2e/frmwrk/shared_context.go
+++ b/test/e2e/frmwrk/shared_context.go
@@ -19,6 +19,7 @@ import (
 	"github.com/metal-stack/metal-go/api/client/network"
 	"github.com/metal-stack/metal-go/api/models"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clusterctlconfig "sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
@@ -338,6 +339,15 @@ func (ee *E2EContext) TeardownMetalStackProject(ctx context.Context) {
 			framework.DeleteNamespace(ctx, framework.DeleteNamespaceInput{
 				Deleter: ee.Environment.Bootstrap.GetClient(),
 				Name:    ns.Name,
+			})
+
+			By(fmt.Sprintf("Waiting for namespace %s to be deleted", ns.Name))
+			Eventually(func() bool {
+				namespace := &corev1.Namespace{}
+				key := client.ObjectKeyFromObject(&ns)
+				return apierrors.IsNotFound(ee.Environment.Bootstrap.GetClient().Get(ctx, key, namespace))
+			}).Should(BeTrue(), func() string {
+				return fmt.Sprintf("timed out waiting for namespace %s to be deleted", ns.Name)
 			})
 		}
 	}


### PR DESCRIPTION
## Description

Currently the e2e tests delete the namespaces used for tests on startup. But deleting these namespaces takes its time. But the test suite does not wait until the deletion is finished.

Then the tests fail as they try to create resources into a namespace that is currently deleting. With this PR we wait for a successful deletion.

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- Nuffin used

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
