### PR TITLE
tests: kamaji lab setup smoke test

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Run tests
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     continue-on-error: true
     strategy:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,64 @@
+---
+name: Lab Integration Test
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: self-hosted
+
+    continue-on-error: true
+    strategy:
+      matrix:
+        flavors:
+          - name: kamaji
+
+    steps:
+    - name: Gain back workspace permissions # https://github.com/actions/checkout/issues/211
+      run: |
+        [ -d "${GITHUB_WORKSPACE}" ] && sudo chown -R $USER:$USER ${GITHUB_WORKSPACE}
+
+    - name: Setup Containerlab
+      run: |
+        bash -c "$(curl -sL https://get.containerlab.dev)"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # set if required:
+        # DESIRED_VERSION: v0.59.0
+
+    - name: Log in to the container registry
+      uses: docker/login-action@v3
+      with:
+        registry: r.metal-stack.io
+        username: ${{ secrets.R_METALSTACK_IO_READ_USER }}
+        password: ${{ secrets.R_METALSTACK_IO_READ_PASSWORD }}
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    # - name: Resolve mini-lab image tags from submodule commit
+    #   run: |
+    #     SUBMODULE_SHA=$(git -C capi-lab/mini-lab rev-parse --short=8 HEAD)
+
+    #     echo "MINI_LAB_VM_IMAGE=ghcr.io/metal-stack/mini-lab-vms:${SUBMODULE_SHA}" >> $GITHUB_ENV
+    #     echo "MINI_LAB_SONIC_IMAGE=ghcr.io/metal-stack/mini-lab-sonic:${SUBMODULE_SHA}" >> $GITHUB_ENV
+
+    - name: Run integration tests
+      shell: bash
+      run: |
+        eval $(make -C capi-lab --silent dev-env)
+        ./capi-lab/test/ci-cleanup.sh
+        ./capi-lab/test/integration.sh
+      env:
+        MINI_LAB_FLAVOR: ${{ matrix.flavors.name }}
+        DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
+        DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -44,13 +44,6 @@ jobs:
       with:
         submodules: true
 
-    # - name: Resolve mini-lab image tags from submodule commit
-    #   run: |
-    #     SUBMODULE_SHA=$(git -C capi-lab/mini-lab rev-parse --short=8 HEAD)
-
-    #     echo "MINI_LAB_VM_IMAGE=ghcr.io/metal-stack/mini-lab-vms:${SUBMODULE_SHA}" >> $GITHUB_ENV
-    #     echo "MINI_LAB_SONIC_IMAGE=ghcr.io/metal-stack/mini-lab-sonic:${SUBMODULE_SHA}" >> $GITHUB_ENV
-
     - name: Run integration tests
       shell: bash
       run: |

--- a/capi-lab/Makefile
+++ b/capi-lab/Makefile
@@ -30,6 +30,11 @@ FIREWALL_EXTERNAL_NETWORKS ?= ["internet-mini-lab"]
 
 IMG ?= ghcr.io/metal-stack/cluster-api-metal-stack-controller:latest
 
+# use specific mini-lab image versions matching the submodule commit to avoid breakage due to incompatible changes in mini-lab
+SUBMODULE_SHA=$(shell git -C mini-lab rev-parse --short=8 HEAD)
+MINI_LAB_VM_IMAGE := $(or $(MINI_LAB_VM_IMAGE),ghcr.io/metal-stack/mini-lab-vms:$(SUBMODULE_SHA))
+MINI_LAB_SONIC_IMAGE := $(or $(MINI_LAB_SONIC_IMAGE),ghcr.io/metal-stack/mini-lab-sonic:$(SUBMODULE_SHA))
+
 ifeq ($(MINI_LAB_FLAVOR),capms)
 DEPLOY_TARGET=deploy-kubeadm
 else ifeq ($(MINI_LAB_FLAVOR),kamaji)

--- a/capi-lab/Makefile
+++ b/capi-lab/Makefile
@@ -49,6 +49,13 @@ else
 $(error Unknown flavor $(MINI_LAB_FLAVOR))
 endif
 
+ifeq ($(CI),true)
+  DOCKER_COMPOSE_RUN_ARG=--no-TTY --rm
+else
+  DOCKER_COMPOSE_RUN_ARG=--rm
+endif
+
+
 .PHONY: up
 up: bake $(DEPLOY_TARGET)
 
@@ -88,11 +95,11 @@ controller:
 
 .PHONY: control-plane-ip
 control-plane-ip:
-	metalctl network ip create --network internet-mini-lab --project $(METAL_PROJECT_ID) --name "$(CLUSTER_NAME)-vip" --type static -o template --template "{{ .ipaddress }}"
+	docker compose -f mini-lab/compose.yaml run $(DOCKER_COMPOSE_RUN_ARG) metalctl network ip create --network internet-mini-lab --project $(METAL_PROJECT_ID) --name "$(CLUSTER_NAME)-vip" --type static -o template --template "{{ .ipaddress }}"
 
 .PHONY: apply-sample-cluster
 apply-sample-cluster:
-	$(eval CONTROL_PLANE_IP = $(shell metalctl network ip list --name "$(CLUSTER_NAME)-vip" -o template --template '{{ .ipaddress }}'))
+	$(eval CONTROL_PLANE_IP = $(shell docker compose -f mini-lab/compose.yaml run $(DOCKER_COMPOSE_RUN_ARG) metalctl network ip list --name "$(CLUSTER_NAME)-vip" -o template --template '{{ .ipaddress }}'))
 	echo  $(CLUSTER_NAME)
 	clusterctl generate cluster $(CLUSTER_NAME) \
 		--kubeconfig=$(KUBECONFIG) \
@@ -104,7 +111,7 @@ apply-sample-cluster:
 
 .PHONY: delete-sample-cluster
 delete-sample-cluster:
-	$(eval CONTROL_PLANE_IP = $(shell metalctl network ip list --name "$(CLUSTER_NAME)-vip" -o template --template '{{ .ipaddress }}'))
+	$(eval CONTROL_PLANE_IP = $(shell docker compose -f mini-lab/compose.yaml run $(DOCKER_COMPOSE_RUN_ARG) metalctl network ip list --name "$(CLUSTER_NAME)-vip" -o template --template '{{ .ipaddress }}'))
 	clusterctl generate cluster $(CLUSTER_NAME) \
 		--kubeconfig=$(KUBECONFIG) \
 		--worker-machine-count 1 \
@@ -120,12 +127,12 @@ mtu-fix:
 
 .PHONY: create-kamaji-tenant
 create-kamaji-tenant:
-	$(eval CONTROL_PLANE_IP = $(shell metalctl network ip list --name "$(CLUSTER_NAME)-vip" -o template --template '{{ .ipaddress }}'))
-	$(eval METAL_NODE_NETWORK_ID = $(shell metalctl network list --project $(METAL_PROJECT_ID) -o template --template '{{ (index . 0).id }}'))
+	$(eval CONTROL_PLANE_IP = $(shell docker compose -f mini-lab/compose.yaml run $(DOCKER_COMPOSE_RUN_ARG) metalctl network ip list --name "$(CLUSTER_NAME)-vip" -o template --template '{{ .ipaddress }}'))
+	$(eval METAL_NODE_NETWORK_ID = $(shell docker compose -f mini-lab/compose.yaml run $(DOCKER_COMPOSE_RUN_ARG) metalctl network list --project $(METAL_PROJECT_ID) -o template --template '{{ (index . 0).id }}'))
 	kubectl --kubeconfig=$(KUBECONFIG) create namespace $(TENANT_NAMESPACE) --dry-run=client -o yaml | kubectl --kubeconfig=$(KUBECONFIG) apply -f -
 	# let MetalLB assign the IP to the tenant cluster control plane service
 	envsubst < kamaji/metallb-tenant-pool.yaml | kubectl --kubeconfig=$(KUBECONFIG) apply -f -
-	docker compose -f compose.yaml -f compose.kamaji.yaml run --rm \
+	docker compose -f compose.yaml -f compose.kamaji.yaml run $(DOCKER_COMPOSE_RUN_ARG) \
 		clusterctl generate cluster $(CLUSTER_NAME) \
 		--target-namespace $(TENANT_NAMESPACE) \
 		--worker-machine-count 1 \
@@ -135,7 +142,7 @@ create-kamaji-tenant:
 
 .PHONY: delete-kamaji-tenant
 delete-kamaji-tenant:
-	docker compose -f compose.yaml -f compose.kamaji.yaml run --rm \
+	docker compose -f compose.yaml -f compose.kamaji.yaml run $(DOCKER_COMPOSE_RUN_ARG) \
 		clusterctl generate cluster $(CLUSTER_NAME) \
 		--target-namespace $(TENANT_NAMESPACE) \
 		--worker-machine-count 1 \

--- a/capi-lab/Makefile
+++ b/capi-lab/Makefile
@@ -65,7 +65,7 @@ deploy-kamaji:
 	docker compose -f compose.yaml -f compose.kamaji.yaml run --rm clusterctl init --addon helm --control-plane kamaji
 	
 	# workaround for a route not being applied successfully in the exit container.
-	docker exec -it exit ip route add 203.0.113.128/25 via 203.0.113.128 dev mini_lab_ext
+	docker exec exit ip route add 203.0.113.128/25 via 203.0.113.128 dev mini_lab_ext
 
 .PHONY: cleanup
 cleanup:

--- a/capi-lab/test/ci-cleanup.sh
+++ b/capi-lab/test/ci-cleanup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Cleanup artifacts of previous runs"
+
+# containerlab will figure out previous run locations from the docker containers
+running_containers=$(docker ps -aq)
+
+if [ ! -z "$running_containers" ]; then
+    previous_topos=$(docker inspect -f '{{ index .Config.Labels "clab-topo-file" }}' $(docker ps -aq))
+    for topo in previous_topos; do
+        previous_lab_dir=$(dirname $topo)
+        mkdir -p "${previous_lab_dir}/clab-mini-lab"
+    done
+fi
+
+make cleanup
+
+echo "Remove containers from previous runs"
+
+previous_mini_lab_containers=$(docker container list --all --filter label=containerlab=mini-lab --quiet)
+
+if [ ! -z "$previous_mini_lab_containers" ]; then
+    docker container rm --force $(docker container list --all --filter label=containerlab=mini-lab --quiet)
+fi

--- a/capi-lab/test/ci-cleanup.sh
+++ b/capi-lab/test/ci-cleanup.sh
@@ -14,7 +14,7 @@ if [ ! -z "$running_containers" ]; then
     done
 fi
 
-make cleanup
+make -C capi-lab cleanup
 
 echo "Remove containers from previous runs"
 

--- a/capi-lab/test/integration.sh
+++ b/capi-lab/test/integration.sh
@@ -69,7 +69,7 @@ if [ "$MINI_LAB_FLAVOR" = "kamaji" ]; then
     echo "Checking if tenant cluster exists"
     if kubectl --kubeconfig ${CLUSTER_NAME}.kubeconfig get nodes | grep -e "Ready"; then
         echo "Nodes have joined the cluster and are ready"
-    else if kubectl --kubeconfig ${CLUSTER_NAME}.kubeconfig get nodes | grep -e "No resources found"; then
+    elif kubectl --kubeconfig ${CLUSTER_NAME}.kubeconfig get nodes | grep -e "No resources found"; then
         echo "Nodes have not joined yet"
         # TODO network issues can't be fixed by this test, so we shouldn't fail the test if the nodes haven't joined yet
         # exit 1

--- a/capi-lab/test/integration.sh
+++ b/capi-lab/test/integration.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -e
-export ANSIBLE_DISPLAY_SKIPPED_HOSTS=false
 
 echo "Starting capi-lab"
 make -C capi-lab

--- a/capi-lab/test/integration.sh
+++ b/capi-lab/test/integration.sh
@@ -70,7 +70,8 @@ if [ "$MINI_LAB_FLAVOR" = "kamaji" ]; then
         echo "Nodes have joined the cluster and are ready"
     elif kubectl --kubeconfig ${CLUSTER_NAME}.kubeconfig get nodes | grep -e "No resources found"; then
         echo "Nodes have not joined yet"
-        # TODO network issues can't be fixed by this test, so we shouldn't fail the test if the nodes haven't joined yet
+        # TODO network issues can't be fixed by this test,
+        # so we shouldn't fail the test if the nodes haven't joined yet
         # exit 1
     fi
 

--- a/capi-lab/test/integration.sh
+++ b/capi-lab/test/integration.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -e
+export ANSIBLE_DISPLAY_SKIPPED_HOSTS=false
+
+echo "Starting capi-lab"
+make -C capi-lab
+eval $(make -C capi-lab --silent dev-env)
+
+echo "Waiting for machines to get to waiting state"
+waiting=$(docker compose -f capi-lab/mini-lab/compose.yaml run --no-TTY --rm metalctl machine ls | grep Waiting | wc -l)
+minWaiting=2
+declare -i attempts=0
+until [ "$waiting" -ge $minWaiting ]
+do
+    if [ "$attempts" -ge 60 ]; then
+        echo "not enough machines in waiting state - timeout reached"
+        exit 1
+    fi
+    echo "$waiting/$minWaiting machines are waiting"
+    sleep 5
+    waiting=$(docker compose -f capi-lab/mini-lab/compose.yaml run --no-TTY --rm metalctl machine ls | grep Waiting | wc -l)
+    attempts=$attempts+1
+done
+echo "$waiting/$minWaiting machines are waiting"
+
+make push-to-capi-lab
+
+if [ "$MINI_LAB_FLAVOR" = "kamaji" ]; then
+
+    echo "Starting kamaji tests"
+
+    echo "Creating control plane IP"
+    export CLUSTER_NAME=kamaji-tenant-test
+    make -C capi-lab control-plane-ip
+
+    echo "Creating kamaji tenant"
+    export TENANT_NAMESPACE=kamaji-tenant-test
+    make -C capi-lab create-kamaji-tenant
+
+    echo "Waiting for machines to get to Phoned Home state"
+    phoned=$(docker compose -f capi-lab/mini-lab/compose.yaml run --no-TTY --rm metalctl machine ls | grep Phoned | wc -l)
+    minPhoned=2
+    declare -i attempts=0
+    until [ "$phoned" -ge $minPhoned ]
+    do
+        if [ "$attempts" -ge 120 ]; then
+            echo "not enough machines phoned home - timeout reached"
+            exit 1
+        fi
+        echo "$phoned/$minPhoned machines have phoned home"
+        sleep 5
+        phoned=$(docker compose -f capi-lab/mini-lab/compose.yaml run --no-TTY --rm metalctl machine ls | grep Phoned | wc -l)
+        attempts+=1
+    done
+    echo "$phoned/$minPhoned machines have phoned home"
+
+    echo "Checking if cluster was created"
+    if kubectl get cluster -n ${TENANT_NAMESPACE} | grep -e "kamaji-tenant-test" -e "Provisioned"; then
+        echo "Cluster resource exists and is provisioned"
+    else
+        echo "Cluster resource does not exist"
+        exit 1
+    fi
+
+
+    echo "Generating kubeconfig for tenant cluster"
+    make -C capi-lab kamaji-tenant-kubeconfig
+
+    echo "Checking if tenant cluster exists"
+    if kubectl --kubeconfig ${CLUSTER_NAME}.kubeconfig get nodes | grep -e "Ready"; then
+        echo "Nodes have joined the cluster and are ready"
+    else if kubectl --kubeconfig ${CLUSTER_NAME}.kubeconfig get nodes | grep -e "No resources found"; then
+        echo "Nodes have not joined yet"
+        # TODO network issues can't be fixed by this test, so we shouldn't fail the test if the nodes haven't joined yet
+        # exit 1
+    fi
+
+fi
+
+echo "Successfully started capi-lab"


### PR DESCRIPTION
## Description

Adds Kamaji smoke tests by launching the Kamaji lab and creating a cluster.
We unfortunately can't test if nodes actually join, as there are problems with `frr` that we can't easily fix from within the test.

We do now also use specific mini-lab image versions matching the mini-lab sub-module commit to avoid breakage due to incompatible changes in mini-lab. 

#### Used AI-Tools ✨

- Copilot with Claude Opus 4.6 for auto-completion and research

Closes https://github.com/metal-stack/mini-lab/issues/287

References:

- https://github.com/metal-stack/mini-lab/pull/289 is precondition. Merge it before and update the sub-module ref.
- https://github.com/metal-stack/cluster-api-provider-metal-stack/pull/134 is also precondition, as it makes multi-tenant-handling easier

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
