### PR TITLE
fix: calico-lab template support for cluster-api v1.11

### DIFF
--- a/config/clusterctl-templates/cluster-template-calico-lab.yaml
+++ b/config/clusterctl-templates/cluster-template-calico-lab.yaml
@@ -133,8 +133,6 @@ spec:
   kubeadmConfigSpec:
     format: ignition
     clusterConfiguration:
-      apiServer:
-        extraArgs: {}
       controllerManager:
         extraArgs:
           cloud-provider: external
@@ -258,8 +256,6 @@ spec:
     spec:
       format: ignition
       clusterConfiguration:
-        apiServer:
-          extraArgs: {}
         controllerManager:
           extraArgs:
             cloud-provider: external


### PR DESCRIPTION
## Description

I am currently working on tests for the `capi-lab` and found out, that it doesn't start a worker node, because the `calico-lab template` contains an unsupported cluster config parameter. (In the calico-template it was removed already: https://github.com/metal-stack/cluster-api-provider-metal-stack/commit/c0b0416af4f650929b74d64dfebfb089ea0dc781#diff-3fc6866002fff75f91ea0cdc693230e58f74520484d7fd8684d1711b5ef5c349)

<!--#### Used AI-Tools ✨

 If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.


- TOOL used for generation
 -->
<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
