### PR TITLE
fix: golangci-lint errors by providing constants and ignore tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - linters:
+          - goconst
+        path: (_test\.go|test/e2e/)
     paths:
       - third_party$
       - builtin$

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -1,0 +1,7 @@
+package controller
+
+const (
+	conditionMessageReconciliationPaused    = "Reconciliation is paused"
+	conditionMessageReconciliationNotPaused = "Reconciliation is not paused"
+	conditionMessageInternalError           = "InternalError"
+)

--- a/internal/controller/metalstackcluster_controller.go
+++ b/internal/controller/metalstackcluster_controller.go
@@ -120,14 +120,14 @@ func (r *MetalStackClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			Status:  metav1.ConditionTrue,
 			Type:    clusterv1.PausedCondition,
 			Reason:  clusterv1.PausedReason,
-			Message: "Reconciliation is paused",
+			Message: conditionMessageReconciliationPaused,
 		})
 	} else {
 		conditions.Set(infraCluster, metav1.Condition{
 			Status:  metav1.ConditionFalse,
 			Type:    clusterv1.PausedCondition,
 			Reason:  clusterv1.NotPausedReason,
-			Message: "Reconciliation is not paused",
+			Message: conditionMessageReconciliationNotPaused,
 		})
 	}
 
@@ -314,7 +314,7 @@ func (r *clusterReconciler) reconcile() error {
 		conditions.Set(r.infraCluster, metav1.Condition{
 			Type:    v1alpha1.ClusterNodeNetworkEnsured,
 			Status:  metav1.ConditionFalse,
-			Reason:  "InternalError",
+			Reason:  conditionMessageInternalError,
 			Message: err.Error(),
 		})
 		return fmt.Errorf("unable to ensure node network: %w", err)
@@ -335,7 +335,7 @@ func (r *clusterReconciler) reconcile() error {
 			conditions.Set(r.infraCluster, metav1.Condition{
 				Status:  metav1.ConditionFalse,
 				Type:    v1alpha1.ClusterFirewallDeploymentEnsured,
-				Reason:  "InternalError",
+				Reason:  conditionMessageInternalError,
 				Message: err.Error(),
 			})
 			return fmt.Errorf("unable to ensure firewall deployment: %w", err)
@@ -356,7 +356,7 @@ func (r *clusterReconciler) reconcile() error {
 			conditions.Set(r.infraCluster, metav1.Condition{
 				Status:  metav1.ConditionFalse,
 				Type:    v1alpha1.ClusterControlPlaneIPEnsured,
-				Reason:  "InternalError",
+				Reason:  conditionMessageInternalError,
 				Message: err.Error(),
 			})
 			return fmt.Errorf("unable to ensure control plane ip: %w", err)

--- a/internal/controller/metalstackfirewalldeployment_controller.go
+++ b/internal/controller/metalstackfirewalldeployment_controller.go
@@ -138,14 +138,14 @@ func (r *MetalStackFirewallDeploymentReconciler) Reconcile(ctx context.Context, 
 			Status:  metav1.ConditionTrue,
 			Type:    clusterv1.PausedCondition,
 			Reason:  clusterv1.PausedReason,
-			Message: "Reconciliation is paused",
+			Message: conditionMessageReconciliationPaused,
 		})
 	} else {
 		conditions.Set(fwdeploy, metav1.Condition{
 			Status:  metav1.ConditionFalse,
 			Type:    clusterv1.PausedCondition,
 			Reason:  clusterv1.PausedReason,
-			Message: "Reconciliation is not paused",
+			Message: conditionMessageReconciliationNotPaused,
 		})
 	}
 
@@ -278,7 +278,7 @@ func (r *firewallDeploymentReconciler) reconcile() error {
 		conditions.Set(r.infraCluster, metav1.Condition{
 			Type:    v1alpha1.ClusterFirewallDeploymentEnsured,
 			Status:  metav1.ConditionFalse,
-			Reason:  "InternalError",
+			Reason:  conditionMessageInternalError,
 			Message: err.Error(),
 		})
 		return fmt.Errorf("unable to ensure firewall deployment: %w", err)

--- a/internal/controller/metalstackmachine_controller.go
+++ b/internal/controller/metalstackmachine_controller.go
@@ -152,14 +152,14 @@ func (r *MetalStackMachineReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			Status:  metav1.ConditionTrue,
 			Type:    clusterv1.PausedCondition,
 			Reason:  clusterv1.PausedReason,
-			Message: "Reconciliation is paused",
+			Message: conditionMessageReconciliationPaused,
 		})
 	} else {
 		conditions.Set(infraMachine, metav1.Condition{
 			Status:  metav1.ConditionFalse,
 			Type:    clusterv1.PausedCondition,
 			Reason:  clusterv1.NotPausedReason,
-			Message: "Reconciliation is not paused",
+			Message: conditionMessageReconciliationNotPaused,
 		})
 	}
 
@@ -359,7 +359,7 @@ func (r *machineReconciler) reconcile() (ctrl.Result, error) {
 			conditions.Set(r.infraMachine, metav1.Condition{
 				Status:  metav1.ConditionFalse,
 				Type:    v1alpha1.ProviderMachineCreated,
-				Reason:  "InternalError",
+				Reason:  conditionMessageInternalError,
 				Message: err.Error(),
 			})
 			return ctrl.Result{}, err
@@ -370,7 +370,7 @@ func (r *machineReconciler) reconcile() (ctrl.Result, error) {
 			conditions.Set(r.infraMachine, metav1.Condition{
 				Status:  metav1.ConditionFalse,
 				Type:    v1alpha1.ProviderMachineCreated,
-				Reason:  "InternalError",
+				Reason:  conditionMessageInternalError,
 				Message: err.Error(),
 			})
 			return ctrl.Result{}, fmt.Errorf("unable to create machine at provider: %w", err)
@@ -594,7 +594,7 @@ func (r *machineReconciler) findProviderMachine() (*models.V1MachineResponse, er
 		conditions.Set(r.infraMachine, metav1.Condition{
 			Status:  metav1.ConditionFalse,
 			Type:    v1alpha1.ProviderMachineCreated,
-			Reason:  "InternalError",
+			Reason:  conditionMessageInternalError,
 			Message: err.Error(),
 		})
 		return nil, err


### PR DESCRIPTION
## Description

The new golangci-lint version made the linter workflow produce some new errors.
This adds some constants where it makes sense and ignores the test files.

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- Claude Sonnet 4.6 for batch edits

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
